### PR TITLE
Update v3.5.1 from upstream

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,20 @@ way to update this template, but currently, we follow a pattern:
 
 ## Upcoming version 2019-XX-XX
 
+## [v3.5.1] 2019-09-17
+
+- [add] add orverriding function `onAdd` and `onRemove` for `CustomOverlayView` in
+  `SearchMapWithGoogleMap` to abide to React rules and do not `unmountComponentAtNode` when a
+  component is rendered by React and use `appendChild` on `onAdd` instead of `draw` to
+  [improve performance](https://github.com/tomchentw/react-google-maps/issues/817).
+  [#1200](https://github.com/sharetribe/flex-template-web/pull/1200)
+- [fix] fix `CustomOverlayView` in `SearchMapWithGoogleMap` to work with new `react-intl` version,
+  overriding `render` method to render child object by using `createPortal` instead of
+  `unstable_renderSubtreeIntoContainer`.
+  [#1200](https://github.com/sharetribe/flex-template-web/pull/1200)
+
+  [v3.5.1]: https://github.com/sharetribe/flex-template-web/compare/v3.5.0...v3.5.1
+
 ## [v3.5.0] 2019-08-29
 
 - [change] Change the design of `BookingBreakdown` and add options to show only dates or booking

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "app",
-  "version": "3.5.0",
+  "version": "3.5.1",
   "private": true,
   "license": "Apache-2.0",
   "dependencies": {


### PR DESCRIPTION
## v3.5.1 [Changes]

- [add] add orverriding function `onAdd` and `onRemove` for `CustomOverlayView` in
  `SearchMapWithGoogleMap` to abide to React rules and do not `unmountComponentAtNode` when a
  component is rendered by React and use `appendChild` on `onAdd` instead of `draw` to
  [improve performance](https://github.com/tomchentw/react-google-maps/issues/817).
  [#1200](https://github.com/sharetribe/flex-template-web/pull/1200)
- [fix] fix `CustomOverlayView` in `SearchMapWithGoogleMap` to work with new `react-intl` version,
  overriding `render` method to render child object by using `createPortal` instead of
  `unstable_renderSubtreeIntoContainer`.
  [#1200](https://github.com/sharetribe/flex-template-web/pull/1200)

  [Changes]: https://github.com/sharetribe/flex-template-web/compare/v3.5.0...v3.5.1
