### PR TITLE
Fix same day detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ https://github.com/sharetribe/flex-template-web/
 
 ## Upcoming version 2019-XX-XX
 
+- [fix] Fix same date detection on TimeRange component.
+  [#38](https://github.com/sharetribe/ftw-time/pull/38)
 - [change] Hide inbox tabs if user doesn't have a listing.
   [#37](https://github.com/sharetribe/ftw-time/pull/37)
 - [change] Change the logo, marketplace color and favicons from Saunatime to Yogatime.

--- a/src/components/BookingTimeInfo/BookingTimeInfo.example.js
+++ b/src/components/BookingTimeInfo/BookingTimeInfo.example.js
@@ -26,6 +26,7 @@ export const DateAndTimeSingleDay = {
     }),
     unitType: LINE_ITEM_UNITS,
     dateType: 'datetime',
+    timeZone: 'Etc/UTC',
   },
   group: 'inbox',
 };
@@ -48,6 +49,7 @@ export const DateAndTimeMultipleDays = {
     }),
     unitType: LINE_ITEM_UNITS,
     dateType: 'datetime',
+    timeZone: 'Etc/UTC',
   },
   group: 'inbox',
 };
@@ -70,6 +72,7 @@ export const OnlyDateSingleDay = {
     }),
     unitType: LINE_ITEM_DAY,
     dateType: 'date',
+    timeZone: 'Etc/UTC',
   },
   group: 'inbox',
 };
@@ -92,6 +95,7 @@ export const OnlyDateMultipleDays = {
     }),
     unitType: LINE_ITEM_DAY,
     dateType: 'date',
+    timeZone: 'Etc/UTC',
   },
   group: 'inbox',
 };
@@ -114,6 +118,7 @@ export const OnlyDateSingleNight = {
     }),
     unitType: LINE_ITEM_NIGHT,
     dateType: 'date',
+    timeZone: 'Etc/UTC',
   },
   group: 'inbox',
 };
@@ -136,6 +141,7 @@ export const OnlyDateMultipleNights = {
     }),
     unitType: LINE_ITEM_NIGHT,
     dateType: 'date',
+    timeZone: 'Etc/UTC',
   },
   group: 'inbox',
 };

--- a/src/components/TimeRange/TimeRange.js
+++ b/src/components/TimeRange/TimeRange.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { instanceOf, string } from 'prop-types';
 import classNames from 'classnames';
-import { daysBetween, formatDateToText } from '../../util/dates';
+import { isSameDay, formatDateToText } from '../../util/dates';
 import { injectIntl, intlShape } from '../../util/reactIntl';
 import { DATE_TYPE_DATE, DATE_TYPE_DATETIME, propTypes } from '../../util/types';
 
@@ -11,7 +11,7 @@ export const TimeRangeComponent = props => {
   const { rootClassName, className, startDate, endDate, dateType, timeZone, intl } = props;
   const start = formatDateToText(intl, startDate, timeZone);
   const end = formatDateToText(intl, endDate, timeZone);
-  const isSingleDay = daysBetween(startDate, endDate) <= 1;
+  const isSingleDay = isSameDay(startDate, endDate, timeZone);
 
   const classes = classNames(rootClassName || css.root, className);
 

--- a/src/containers/InboxPage/__snapshots__/InboxPage.test.js.snap
+++ b/src/containers/InboxPage/__snapshots__/InboxPage.test.js.snap
@@ -787,7 +787,10 @@ exports[`InboxPage matches snapshot 3`] = `
           className=""
         >
           <span>
-            Feb 15, 12:00 AM - 12:00 AM
+            Feb 15, 12:00 AM - 
+          </span>
+          <span>
+            Feb 16, 12:00 AM
           </span>
         </div>
       </div>
@@ -1205,7 +1208,10 @@ exports[`InboxPage matches snapshot 5`] = `
           className=""
         >
           <span>
-            Feb 15, 12:00 AM - 12:00 AM
+            Feb 15, 12:00 AM - 
+          </span>
+          <span>
+            Feb 16, 12:00 AM
           </span>
         </div>
       </div>

--- a/src/util/dates.js
+++ b/src/util/dates.js
@@ -420,6 +420,21 @@ export const daysBetween = (startDate, endDate) => {
 };
 
 /**
+ * Check that the given dates are pointing to the same day.
+ *
+ * @param {Date} date1 first date object
+ * @param {Date} date2 second date object
+ * @param {String} timeZone (if omitted local time zone is used)
+ *
+ * @returns {boolean} true if Date objects are pointing to the same day on given time zone.
+ */
+export const isSameDay = (date1, date2, timeZone) => {
+  const d1 = timeZone ? moment(date1).tz(timeZone) : moment(date1);
+  const d2 = timeZone ? moment(date2).tz(timeZone) : moment(date2);
+  return d1.isSame(d2, 'day');
+};
+
+/**
  * Calculate the number of minutes between the given dates
  *
  * @param {Date} startDate start of the time period

--- a/src/util/dates.test.js
+++ b/src/util/dates.test.js
@@ -13,6 +13,7 @@ import {
   getEndHours,
   nightsBetween,
   daysBetween,
+  isSameDay,
   minutesBetween,
   monthIdStringInTimeZone,
   formatDate,
@@ -240,6 +241,24 @@ describe('date utils', () => {
       const start = new Date(2017, 0, 1, 10, 35, 0);
       const end = new Date(2017, 0, 1, 10, 55, 0);
       expect(minutesBetween(start, end)).toEqual(20);
+    });
+  });
+
+  describe('isSameDay()', () => {
+    it('should fail if the dates are pointing to different days', () => {
+      const d1 = new Date(Date.UTC(2019, 0, 1, 10, 0, 0));
+      const d2 = new Date(Date.UTC(2019, 0, 2, 10, 0, 0));
+      expect(isSameDay(d1, d2, 'Etc/UTC')).toBeFalsy();
+
+      // 1 second difference around midnight
+      const d3 = new Date(Date.UTC(2019, 0, 1, 23, 59, 59));
+      const d4 = new Date(Date.UTC(2019, 0, 2, 0, 0, 0));
+      expect(isSameDay(d3, d4, 'Etc/UTC')).toBeFalsy();
+    });
+    it('should succeed if the dates are pointing to the same days', () => {
+      const d1 = new Date(Date.UTC(2019, 0, 1, 10, 0, 0));
+      const d2 = new Date(Date.UTC(2019, 0, 1, 10, 0, 0));
+      expect(isSameDay(d1, d2, 'Etc/UTC')).toBeTruthy();
     });
   });
 


### PR DESCRIPTION
Single day detection doesn't work with "thu 10 am - fri 10 am"
Those should print 
`${start.dateAndTime} - ${end.dateAndTime}` instead of 
`${start.date}, ${start.time} - ${end.time}`