### PR TITLE
Fix the listing link in Topbar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ https://github.com/sharetribe/flex-template-web/
 
 ## Upcoming version 2019-XX-XX
 
+- [fix] Fix the listing link on `Topbar` so that link works also with listings in draft or pending
+  approval states. [#41](https://github.com/sharetribe/ftw-time/pull/41)
 - [change] Remove listings section from `ProfilePage`.
   [#43](https://github.com/sharetribe/ftw-time/pull/43)
 - [fix] Fix proptype checks for FieldDateAndTimeInput and FieldDateInput.

--- a/src/components/Topbar/Topbar.js
+++ b/src/components/Topbar/Topbar.js
@@ -138,6 +138,7 @@ class TopbarComponent extends Component {
       currentUser,
       currentUserHasListings,
       currentUserListing,
+      currentUserListingFetched,
       currentUserHasOrders,
       currentPage,
       notificationCount,
@@ -220,6 +221,7 @@ class TopbarComponent extends Component {
             className={desktopClassName}
             currentUserHasListings={currentUserHasListings}
             currentUserListing={currentUserListing}
+            currentUserListingFetched={currentUserListingFetched}
             currentUser={currentUser}
             currentPage={currentPage}
             initialSearchFormValues={initialSearchFormValues}

--- a/src/components/TopbarDesktop/TopbarDesktop.js
+++ b/src/components/TopbarDesktop/TopbarDesktop.js
@@ -4,7 +4,6 @@ import { FormattedMessage, intlShape } from '../../util/reactIntl';
 import classNames from 'classnames';
 import { ACCOUNT_SETTINGS_PAGES } from '../../routeConfiguration';
 import { propTypes } from '../../util/types';
-import { createSlug } from '../../util/urlHelpers';
 import {
   Avatar,
   InlineTextButton,
@@ -14,6 +13,7 @@ import {
   MenuContent,
   MenuItem,
   NamedLink,
+  ListingLink,
   OwnListingLink,
 } from '../../components';
 import { TopbarSearchForm } from '../../forms';
@@ -28,6 +28,7 @@ const TopbarDesktop = props => {
     rootClassName,
     currentUserHasListings,
     currentUserListing,
+    currentUserListingFetched,
     notificationCount,
     intl,
     isAuthenticated,
@@ -129,26 +130,27 @@ const TopbarDesktop = props => {
     </NamedLink>
   );
 
-  const listingLink = currentUserListing ? (
-    <NamedLink
-      className={css.createListingLink}
-      name="ListingPage"
-      params={{
-        id: currentUserListing.id.uuid,
-        slug: createSlug(currentUserListing.attributes.title),
-      }}
-    >
-      <span className={css.createListing}>
-        <FormattedMessage id="TopbarDesktop.viewListing" />
-      </span>
-    </NamedLink>
-  ) : (
-    <NamedLink className={css.createListingLink} name="NewListingPage">
-      <span className={css.createListing}>
-        <FormattedMessage id="TopbarDesktop.createListing" />
-      </span>
-    </NamedLink>
-  );
+  const listingLink =
+    authenticatedOnClientSide && currentUserListingFetched && currentUserListing ? (
+      <ListingLink
+        className={css.createListingLink}
+        listing={currentUserListing}
+        children={
+          <span className={css.createListing}>
+            <FormattedMessage id="TopbarDesktop.viewListing" />
+          </span>
+        }
+      />
+    ) : null;
+
+  const createListingLink =
+    isAuthenticatedOrJustHydrated && !(currentUserListingFetched && !currentUserListing) ? null : (
+      <NamedLink className={css.createListingLink} name="NewListingPage">
+        <span className={css.createListing}>
+          <FormattedMessage id="TopbarDesktop.createListing" />
+        </span>
+      </NamedLink>
+    );
 
   return (
     <nav className={classes}>
@@ -161,6 +163,7 @@ const TopbarDesktop = props => {
       </NamedLink>
       {search}
       {listingLink}
+      {createListingLink}
       {inboxLink}
       {profileMenu}
       {signupLink}

--- a/src/components/TopbarDesktop/__snapshots__/TopbarDesktop.test.js.snap
+++ b/src/components/TopbarDesktop/__snapshots__/TopbarDesktop.test.js.snap
@@ -109,19 +109,6 @@ exports[`TopbarDesktop data matches snapshot 1`] = `
   </form>
   <a
     className=""
-    href="/l/new"
-    onClick={[Function]}
-    style={Object {}}
-    title={null}
-  >
-    <span>
-      <span>
-        TopbarDesktop.createListing
-      </span>
-    </span>
-  </a>
-  <a
-    className=""
     href="/inbox/sales"
     onClick={[Function]}
     style={Object {}}

--- a/src/containers/TopbarContainer/TopbarContainer.js
+++ b/src/containers/TopbarContainer/TopbarContainer.js
@@ -17,6 +17,7 @@ export const TopbarContainerComponent = props => {
     currentUser,
     currentUserHasListings,
     currentUserListing,
+    currentUserListingFetched,
     currentUserHasOrders,
     history,
     isAuthenticated,
@@ -39,6 +40,7 @@ export const TopbarContainerComponent = props => {
       currentUser={currentUser}
       currentUserHasListings={currentUserHasListings}
       currentUserListing={currentUserListing}
+      currentUserListingFetched={currentUserListingFetched}
       currentUserHasOrders={currentUserHasOrders}
       history={history}
       isAuthenticated={isAuthenticated}
@@ -71,6 +73,7 @@ TopbarContainerComponent.propTypes = {
   currentSearchParams: object,
   currentUser: propTypes.currentUser,
   currentUserHasListings: bool.isRequired,
+  currentUserListingFetched: bool.isRequired,
   currentUserListing: propTypes.ownListing,
   currentUserHasOrders: bool,
   isAuthenticated: bool.isRequired,
@@ -97,6 +100,7 @@ const mapStateToProps = state => {
     currentUser,
     currentUserHasListings,
     currentUserListing,
+    currentUserListingFetched,
     currentUserHasOrders,
     currentUserNotificationCount: notificationCount,
     sendVerificationEmailInProgress,
@@ -108,6 +112,7 @@ const mapStateToProps = state => {
     currentUser,
     currentUserHasListings,
     currentUserListing,
+    currentUserListingFetched,
     currentUserHasOrders,
     notificationCount,
     isAuthenticated,

--- a/src/ducks/user.duck.js
+++ b/src/ducks/user.duck.js
@@ -66,6 +66,7 @@ const initialState = {
   sendVerificationEmailInProgress: false,
   sendVerificationEmailError: null,
   currentUserListing: null,
+  currentUserListingFetched: false,
 };
 
 export default function reducer(state = initialState, action = {}) {
@@ -90,6 +91,7 @@ export default function reducer(state = initialState, action = {}) {
         currentUserNotificationCount: 0,
         currentUserNotificationCountError: null,
         currentUserListing: null,
+        currentUserListingFetched: false,
       };
 
     case FETCH_CURRENT_USER_HAS_LISTINGS_REQUEST:
@@ -99,6 +101,7 @@ export default function reducer(state = initialState, action = {}) {
         ...state,
         currentUserHasListings: payload.hasListings,
         currentUserListing: payload.listing,
+        currentUserListingFetched: true,
       };
     case FETCH_CURRENT_USER_HAS_LISTINGS_ERROR:
       console.error(payload); // eslint-disable-line


### PR DESCRIPTION
- Use `ListingLink` instead of `NamedLink` so that different listing states (published, draft, pending approval) are taken into account
- Save `currentUserListingFetched` information to store when fetching the `currentUserListing` so that we can show the correct link without blinking the wrong one first 