### PR TITLE
Fix example process email templates date formatting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ https://github.com/sharetribe/flex-template-web/
 
 ## Upcoming version 2019-XX-XX
 
+- [fix] Fix date formatting in example tx process email templates
+  [#48](https://github.com/sharetribe/ftw-time/pull/48)
 - [change] Change images and update favicons. Also, update links on the `LandingPage`. Make the
   `OwnListingLink` component more generic so that it can be used also in the `SectionHowItWorks`.
   [#42](https://github.com/sharetribe/ftw-time/pull/42/)

--- a/ext/transaction-process/templates/booking-request-accepted/booking-request-accepted-html.html
+++ b/ext/transaction-process/templates/booking-request-accepted/booking-request-accepted-html.html
@@ -4,13 +4,13 @@
 
 {{~#*inline "format-date"~}}
 {{#with transaction.listing.availability-plan}}
-{{date d format="hh:mm a" tz=timezone}} on {{date date format="MMM d, YYYY" tz=timezone}}
+{{date date format="h:mm a" tz=timezone}} on {{date date format="MMM d, YYYY" tz=timezone}}
 {{/with}}
 {{~/inline~}}
 
 {{~#*inline "format-day-time"~}}
 {{#with transaction.listing.availability-plan}}
-{{date date format="EE hh:mm a" tz=timezone}}
+{{date date format="EE h:mm a" tz=timezone}}
 {{/with}}
 {{~/inline~}}
 
@@ -70,8 +70,8 @@
           <th class="right">{{> format-day-time date=booking.end}}</th>
         </tr>
         <tr class="bottom-row">
-          <th class="left">{{> format-month-date date=booking.start format="MMM d"}}</th>
-          <th class="right">{{> format-month-date date=booking.end format="MMM d"}}</th>
+          <th class="left">{{> format-month-date date=booking.start}}</th>
+          <th class="right">{{> format-month-date date=booking.end}}</th>
         </tr>
       </thead>
       <tbody>

--- a/ext/transaction-process/templates/booking-request-auto-declined/booking-request-auto-declined-html.html
+++ b/ext/transaction-process/templates/booking-request-auto-declined/booking-request-auto-declined-html.html
@@ -1,6 +1,6 @@
 {{~#*inline "format-date"~}}
 {{#with transaction.listing.availability-plan}}
-{{date d format="hh:mm a" tz=timezone}} on {{date date format="MMM d, YYYY" tz=timezone}}
+{{date date format="h:mm a" tz=timezone}} on {{date date format="MMM d, YYYY" tz=timezone}}
 {{/with}}
 {{~/inline~}}
 

--- a/ext/transaction-process/templates/booking-request-declined/booking-request-declined-html.html
+++ b/ext/transaction-process/templates/booking-request-declined/booking-request-declined-html.html
@@ -1,6 +1,6 @@
 {{~#*inline "format-date"~}}
 {{#with transaction.listing.availability-plan}}
-{{date d format="hh:mm a" tz=timezone}} on {{date date format="MMM d, YYYY" tz=timezone}}
+{{date date format="h:mm a" tz=timezone}} on {{date date format="MMM d, YYYY" tz=timezone}}
 {{/with}}
 {{~/inline~}}
 

--- a/ext/transaction-process/templates/money-paid/money-paid-html.html
+++ b/ext/transaction-process/templates/money-paid/money-paid-html.html
@@ -4,13 +4,13 @@
 
 {{~#*inline "format-date"~}}
 {{#with transaction.listing.availability-plan}}
-{{date d format="hh:mm a" tz=timezone}} on {{date date format="MMM d, YYYY" tz=timezone}}
+{{date date format="h:mm a" tz=timezone}} on {{date date format="MMM d, YYYY" tz=timezone}}
 {{/with}}
 {{~/inline~}}
 
 {{~#*inline "format-day-time"~}}
 {{#with transaction.listing.availability-plan}}
-{{date date format="EE hh:mm a" tz=timezone}}
+{{date date format="EE h:mm a" tz=timezone}}
 {{/with}}
 {{~/inline~}}
 
@@ -69,8 +69,8 @@
           <th class="right">{{> format-day-time date=booking.end}}</th>
         </tr>
         <tr class="bottom-row">
-          <th class="left">{{> format-month-date date=booking.start format="MMM d"}}</th>
-          <th class="right">{{> format-month-date date=booking.end format="MMM d"}}</th>
+          <th class="left">{{> format-month-date date=booking.start}}</th>
+          <th class="right">{{> format-month-date date=booking.end}}</th>
         </tr>
       </thead>
       <tbody>

--- a/ext/transaction-process/templates/new-booking-request/new-booking-request-html.html
+++ b/ext/transaction-process/templates/new-booking-request/new-booking-request-html.html
@@ -4,13 +4,13 @@
 
 {{~#*inline "format-date"~}}
 {{#with transaction.listing.availability-plan}}
-{{date d format="hh:mm a" tz=timezone}} on {{date date format="MMM d, YYYY" tz=timezone}}
+{{date date format="h:mm a" tz=timezone}} on {{date date format="MMM d, YYYY" tz=timezone}}
 {{/with}}
 {{~/inline~}}
 
 {{~#*inline "format-day-time"~}}
 {{#with transaction.listing.availability-plan}}
-{{date date format="EE hh:mm a" tz=timezone}}
+{{date date format="EE h:mm a" tz=timezone}}
 {{/with}}
 {{~/inline~}}
 
@@ -65,8 +65,8 @@
           <th class="right">{{> format-day-time date=booking.end}}</th>
         </tr>
         <tr class="bottom-row">
-          <th class="left">{{> format-month-date date=booking.start format="MMM d"}}</th>
-          <th class="right">{{> format-month-date date=booking.end format="MMM d"}}</th>
+          <th class="left">{{> format-month-date date=booking.start}}</th>
+          <th class="right">{{> format-month-date date=booking.end}}</th>
         </tr>
       </thead>
       <tbody>


### PR DESCRIPTION
Fixes an inline date formatting helper.

Improves showing times with in 12h format so that two digits are not used for the hour if not needed: 09:45 PM -> 9:45 PM.